### PR TITLE
hammerhead: powerhal: dereference data pointer

### DIFF
--- a/power/power_hammerhead.c
+++ b/power/power_hammerhead.c
@@ -339,7 +339,7 @@ static void power_set_interactive(__attribute__((unused)) struct power_module *m
 }
 
 static void power_hint( __attribute__((unused)) struct power_module *module,
-                      power_hint_t hint, __attribute__((unused)) void *data)
+                      power_hint_t hint, void *data)
 {
     int cpu, ret;
 
@@ -350,7 +350,7 @@ static void power_hint( __attribute__((unused)) struct power_module *module,
             break;
 #if 0
         case POWER_HINT_VSYNC:
-            ALOGV("POWER_HINT_VSYNC %s", (data ? "ON" : "OFF"));
+            ALOGV("POWER_HINT_VSYNC %s", ((*(int32_t *)data) ? "ON" : "OFF"));
             break;
 #endif
         case POWER_HINT_VIDEO_ENCODE:
@@ -359,7 +359,7 @@ static void power_hint( __attribute__((unused)) struct power_module *module,
 
         case POWER_HINT_LOW_POWER:
              pthread_mutex_lock(&low_power_mode_lock);
-             if (data) {
+             if (*(int32_t *)data) {
                  low_power_mode = true;
                  for (cpu = 0; cpu < TOTAL_CPUS; cpu++) {
                      sysfs_write(cpu_path_min[cpu], LOW_POWER_MIN_FREQ);


### PR DESCRIPTION
Solves the issue of being stuck in low_power_mode after disabling
battery save mode.

Change-Id: Ie96d44e564679b11aa122fadb34f6d1ac21a5700
(cherry picked from commit a1e44b7593899bca8a0e27c9918205f45dcfbe33)